### PR TITLE
Ensure that the filter returns a value 

### DIFF
--- a/src/IDealGateway.php
+++ b/src/IDealGateway.php
@@ -75,10 +75,13 @@ class Pronamic_WP_Pay_Extensions_Charitable_IDealGateway extends Pronamic_WP_Pay
 	 *
 	 * @since   1.0.2
 	 */
-	public static function form_field_template( $arg, $field, $form, $index ) {
+	public static function form_field_template( $template, $field, $form, $index ) {
 		if ( 'pronamic-pay-input-html' === $field['key'] ) {
 			echo $field['gateway']->get_input_html();
+			return;
 		}
+
+		return $template;
 	}
 
 	/**


### PR DESCRIPTION
Otherwise, this breaks other Charitable extensions that implement their own custom templates for certain form fields.