### PR TITLE
Add process_donation() method to make sure Pronamic gateway works cor…

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -82,6 +82,15 @@ class Pronamic_WP_Pay_Extensions_Charitable_Gateway extends Charitable_Gateway {
 	/**
 	 * Process donation.
 	 *
+	 * @since   1.1.1
+	 */
+	public static function process_donation( $return, $donation_id, $processor ) {
+		return self::pronamic_process_donation( $return, $donation_id, $processor, new self() );
+	}
+
+	/**
+	 * Process donation.
+	 *
 	 * @since   1.0.0
 	 * @param   mixed                          $return
 	 * @param   int                            $donation_id


### PR DESCRIPTION
The Pronamic gateway in Charitable (Charitable > Settings > Payment Gateways) does not process because it misses the `process_donation()` method. This also causes a warning because `call_user_func_array()` fails. See https://wordpress.org/support/topic/problem-with-charitable-and-pronamic/